### PR TITLE
Use MPI futures for easy parallel task distribution

### DIFF
--- a/mpi_global.py
+++ b/mpi_global.py
@@ -1,94 +1,70 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-# run me with: mpiexec -n 4 python3 mpi_global.py
+# run me with: mpiexec -n $CPUS python3 -m mpi4py.futures mpi_global.py
 
 import meshio
 import numpy as np
 import time
-
 from mpi4py import MPI
+from mpi4py.futures import MPIPoolExecutor
 
 from LECMesh import LECMesh
-
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 
-
+#############################################################################
+# We need these variables to to be in the global scope, so all CPUs have them
 infile = "earth/data/globe.vtk"
 outfile = "outputs/costed_globe.vtk"
+
 mesh = meshio.read(infile)
-
-max_fuel = 2500
-
 points_above_sealevel = np.nonzero(mesh.point_data['Z'] >= 0)[0]
-if rank == 0:
-    print("Total starting points available: ", points_above_sealevel.shape[0], flush=True)
-    
-    # The first CPU can figure out how to split up all the data to send out to the others
-    point_list_split = np.array_split(points_above_sealevel, comm.size, axis=0)
+parprint("Total starting points available: ", points_above_sealevel.shape[0], flush=True)
 
-    # Setup the output file:
-    mesh.point_data['cost'] = np.zeros_like(mesh.point_data['Z'])
-    
-else:
-    point_list_split = None
-    
-# All the CPUs get their list of points to work on
-my_points = comm.scatter(point_list_split, root=0)
+# Setup the output file:
+mesh.point_data['cost'] = np.zeros_like(mesh.point_data['Z'])
 
-print("Proc {} will work on {} points".format(rank, my_points.shape[0]), flush=True)
+max_fuel = 2500 # A smaller value means visiting far fewer nodes, so it speeds things up a lot
+#############################################################################
 
 
-# Setup the LECMesh functions via class instantiation. Each CPU gets their own object
-lm = LECMesh(mesh, max_fuel, neighbours_cache_size = points_above_sealevel.shape[0])
-
-
-def process_points_with_feedback(points):
+def parprint(*args, **kwargs):
     """
-    This function is overly complicated, only because it's nice to see progress
+    Print if on CPU 0
     """
+    if rank == 0:
+        print(*args, **kwargs)
+
+
+def init(point):
+    """
+    This function sets up an LECMesh object for each CPU.
+    From: https://groups.google.com/d/msg/mpi4py/k7Hc6raaWgY/PSbrygDTAQAJ
+    """
+    global lm
+    try:
+        lm
+    except NameError:
+        print("{}: creating lm obj".format(rank))
+        # Setup the LECMesh functions via class instantiation. 
+        lm = LECMesh(mesh, max_fuel, neighbours_cache_size = points_above_sealevel.shape[0])
+    return lm.get_dist_from_point(point)
+
+
+if __name__ == "__main__":
+
     all_costs = []
-    start = 0
-    inc = 100
-    stop = inc
-    
-    while start < points.shape[0]:
-        start_time = time.time()
-        
-        # the real work is being done here
-        costs = list(map(lm.get_dist_from_point, points[start:stop]))
-        # you could replace this whole function with just:
-        #     return list(map(lm.get_dist_from_point, points))
-        # I think...
-        
-        print("{}: points: {: 7d} to {: 7d} took {:.3f} s. % complete: {:.3f}".format(rank, 
-                                                                                 start, 
-                                                                                 stop, 
-                                                                                 time.time() - start_time, 
-                                                                                 (stop/(len(points)-1)) * 100), flush=True)
+    with MPIPoolExecutor() as ex:
+        for res in ex.map(init, points_above_sealevel, chunksize=20):
+            all_costs.append(res)
+            parprint('Progress: {: 4.3f} %'.format((len(all_costs)/points_above_sealevel.shape[0]) * 100))
 
-        # Save the data
-        all_costs.extend(costs)
-        
-        # move to the next chunk of data
-        start += inc
-        stop += inc
-        if stop >= len(points):
-            stop = len(points)-1
-            
-    return all_costs
-
-
-my_costs = process_points_with_feedback(my_points)
-
-# Sync all the processors up
-cost_list = comm.gather(my_costs)
-
-# The first CPU can now write out all the data
-if comm.rank == 0:
-    for costs in cost_list:
-        for i in costs:
+    # The first CPU can now write out all the data
+    parprint("Writing out the data...")
+    if rank == 0:
+        for i in all_costs:
             mesh.point_data['cost'][i[0]] = i[1]
-    meshio.write(outfile, mesh)
+        meshio.write(outfile, mesh)
+    parprint("Done")

--- a/mpi_tas.py
+++ b/mpi_tas.py
@@ -1,94 +1,61 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-# run me with: mpiexec -n 4 python3 mpi_tas.py
+# run me with: mpiexec -n $CPUS python3 -m mpi4py.futures mpi_tas.py
 
 import meshio
 import numpy as np
 import time
 
 from mpi4py import MPI
+from mpi4py.futures import MPIPoolExecutor
 
 from LECMesh import LECMesh
-
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 
-
 infile = "australia/data/TAS.vtk"
 outfile = "outputs/costed_tas_parallel.vtk"
+
+def parprint(*args, **kwargs):
+    if rank == 0:
+        print(*args, **kwargs)
+
+def init(point):
+    global lm
+    try:
+        lm
+    except NameError:
+        print("{}: creating lm obj".format(rank))
+        lm = LECMesh(mesh, max_fuel, neighbours_cache_size = points_above_sealevel.shape[0])
+    # Setup the LECMesh functions via class instantiation. 
+
+    return lm.get_dist_from_point(point)
+
+
 mesh = meshio.read(infile)
+points_above_sealevel = np.nonzero(mesh.point_data['Z'] >= 0)[0]
+parprint("Total starting points available: ", points_above_sealevel.shape[0], flush=True)
+
+# Setup the output file:
+mesh.point_data['cost'] = np.zeros_like(mesh.point_data['Z'])
 
 max_fuel = 2500 # A smaller value means visiting far fewer nodes, so it speeds things up a lot
 
-points_above_sealevel = np.nonzero(mesh.point_data['Z'] >= 0)[0]
-if rank == 0:
-    print("Total starting points available: ", points_above_sealevel.shape[0], flush=True)
     
-    # The first CPU can figure out how to split up all the data to send out to the others
-    point_list_split = np.array_split(points_above_sealevel, comm.size, axis=0)
+if __name__ == "__main__":
 
-    # Setup the output file:
-    mesh.point_data['cost'] = np.zeros_like(mesh.point_data['Z'])
-    
-else:
-    point_list_split = None
-    
-# All the CPUs get their list of points to work on
-my_points = comm.scatter(point_list_split, root=0)
-
-print("Proc {} will work on {} points".format(rank, my_points.shape[0]), flush=True)
-
-
-# Setup the LECMesh functions via class instantiation. Each CPU gets their own object
-lm = LECMesh(mesh, max_fuel, neighbours_cache_size = points_above_sealevel.shape[0])
-
-
-def process_points_with_feedback(points):
-    """
-    This function is overly complicated, only because it's nice to see progress
-    """
     all_costs = []
-    start = 0
-    inc = 50
-    stop = inc
-    
-    while start < points.shape[0]:
-        start_time = time.time()
-        
-        # the real work is being done here
-        costs = list(map(lm.get_dist_from_point, points[start:stop]))
-        # you could replace this whole function with just:
-        #     return list(map(lm.get_dist_from_point, points))
-        # I think...
-        
-        print("{}: points: {: 7d} to {: 7d} took {:.3f} s. % complete: {:.3f}".format(rank, 
-                                                                                 start, 
-                                                                                 stop, 
-                                                                                 time.time() - start_time, 
-                                                                                 (stop/(len(points)-1)) * 100), flush=True)
+    with MPIPoolExecutor() as ex:
+        for res in ex.map(init, points_above_sealevel, chunksize=20):
+            all_costs.append(res)
+            parprint('Progress: {: 4.3f} %'.format((len(all_costs)/points_above_sealevel.shape[0]) * 100))
 
-        # Save the data
-        all_costs.extend(costs)
-        
-        # move to the next chunk of data
-        start += inc
-        stop += inc
-        if stop >= len(points):
-            stop = len(points)-1
-            
-    return all_costs
+    parprint(len(all_costs))
 
-
-my_costs = process_points_with_feedback(my_points)
-
-# Sync all the processors up
-cost_list = comm.gather(my_costs)
-
-# The first CPU can now write out all the data
-if comm.rank == 0:
-    for costs in cost_list:
-        for i in costs:
+    # The first CPU can now write out all the data
+    if rank == 0:
+        for i in all_costs:
             mesh.point_data['cost'][i[0]] = i[1]
-    meshio.write(outfile, mesh)
+        meshio.write(outfile, mesh)


### PR DESCRIPTION
Using MPI futures means that CPUs will be feed more work as they need it, rather than splitting up the array into `length / cpus` sized chunks.

